### PR TITLE
fix: TypeError: cndy.state.goLiveDate.toNumber is not a function

### DIFF
--- a/src/candy-machine.ts
+++ b/src/candy-machine.ts
@@ -207,7 +207,7 @@ export const getCandyMachineState = async (
       isActive: false,
       isPresale: false,
       isWhitelistOnly: false,
-      goLiveDate,
+      goLiveDate: state.data.goLiveDate,
       treasury: state.wallet,
       tokenMint: state.tokenMint,
       gatekeeper: state.data.gatekeeper,


### PR DESCRIPTION
This PR fixes #2 

Tested in mainnet with

- goLiveDate: null
- and a normal goLiveDate.

Without the fix the following error occurs. Correct date according to the [transaction](https://explorer.solana.com/tx/iX4V3maTu2qYUdarsUsYgrkgNbt4u5njvRsWKuaqBfubFhHVSaEyvVpP6fvzf67qMRwX2DMGirR4YBoqN1VM9kD) would have been 1658082600

- Frontend error: ![image](https://cdn.discordapp.com/attachments/898625218426339448/997492808028000286/Screenshot_2.jpg)
-  More console info: 
![image](https://user-images.githubusercontent.com/93528482/179252752-00a81a05-247b-47e7-8154-618f4f27226e.png)

Thank you to discord user anvog#7777 who proposed that fix.