### PR TITLE
Fix build by downgrading eslint package

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@types/styled-components": "^5.1.14",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
     "@typescript-eslint/parser": "^5.30.6",
-    "eslint": "^8.19.0",
+    "eslint": "^7.11.0",
     "eslint-plugin-react": "^7.30.1",
     "prettier": "^2.7.1"
   }


### PR DESCRIPTION
build was failing because of dependency issues.

example screenshot from discord:
![grafik](https://user-images.githubusercontent.com/93528482/181049121-f7f71914-1b2d-475e-967a-39f694d825c3.png)

The propesed fix includes what yarn is telling us. 

yarn install
yarn start
working locally and in the github action.