### PR TITLE
check-freeze-pda-fix

### DIFF
--- a/src/candy-machine.ts
+++ b/src/candy-machine.ts
@@ -224,8 +224,13 @@ export const getFreezePdaState = async (
   program: anchor.Program,
   freezePda: anchor.web3.PublicKey
 ): Promise<any> => {
-  const state: any = await program.account.freezePda.fetch(freezePda);
-  return state;
+  try {
+    const state = await program.account.freeze.fetch(freezePda);
+    return state;
+
+  } catch (error) {
+    return null
+  }
 };
 
 const getMasterEdition = async (
@@ -370,7 +375,7 @@ export const createAccountsForMint = async (
         [signers],
         SequenceType.StopOnFailure,
         "singleGossip",
-        () => {},
+        () => { },
         () => false,
         undefined,
         [],
@@ -520,10 +525,14 @@ export const mintOneToken = async (
   );
 
   const freezePda = (await getFreezePda(candyMachineAddress))[0];
+  console.log(freezePda.toString())
+
+
   const freezePdaState = await getFreezePdaState(
     candyMachine.program,
     freezePda
   );
+
   console.log("Freeze state: ");
   console.log(freezePdaState);
 
@@ -635,7 +644,7 @@ export const mintOneToken = async (
         signersMatrix,
         SequenceType.StopOnFailure,
         "singleGossip",
-        () => {},
+        () => { },
         () => false,
         undefined,
         beforeTransactions,


### PR DESCRIPTION
** Issue **

As candymachine freeze pda accounts don't seem to be created untill freeze is enabled on the candymachine this leaves the freezePda with zero data.

A call to fetch freezePda data occurs which throws an error that the account doesn't exist within the anchor funtion. If freeze isn't enabled on the candymachinethis throws and exits the function with  a "sold out toast".

** Fix **
Wrapped the fetch data call in a try catch to mitigate the thrown error so the value can be returned as null if data doesn't exist on the account and proceed with the mint funciton. 

