### PR TITLE
Add Version explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Metaplex Candy Machine Reference UI
+# Metaplex Candy Machine v2 Reference UI
+> [!IMPORTANT]  
+> This UI is only compatible to the old Candy Machine V2. Multiple new Versions have been released in the meantime: 
+
+If you want to use Candy Machine V3 the [corresponding page](https://developers.metaplex.com/candy-machine) on the developer hub.
+
+There also is a new [Core Candy Machine](https://developers.metaplex.com/core-candy-machine) for the latest Metaplex NFT standard [Core](https://developers.metaplex.com/core).


### PR DESCRIPTION
Currently it only says Candy Machine Reference UI. This is confusing for users who "accidentaly" find this repository.